### PR TITLE
feat: environment variable error handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::str::FromStr;
 
 pub struct Config {
     pub cors_allow_origin: String,
@@ -8,14 +9,28 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Self {
-        let cors_allow_origin = env::var("CORS_ALLOW_ORIGIN").unwrap();
-        let database_url = env::var("DATABASE_URL").unwrap();
-        let server_port = env::var("PORT").unwrap().parse::<u16>().unwrap();
+        let cors_allow_origin = Config::env_var::<String>("CORS_ALLOW_ORIGIN");
+        let database_url = Config::env_var::<String>("DATABASE_URL");
+        let server_port = Config::env_var::<u16>("PORT");
 
         Self {
             cors_allow_origin,
             database_url,
             server_port,
         }
+    }
+
+    fn env_var<T: FromStr>(key: &str) -> T {
+        let value =
+            env::var(key).unwrap_or_else(|_| panic!("Missing environment variable: {}", key));
+
+        if let Ok(parsed) = str::parse::<T>(&value) {
+            return parsed;
+        }
+
+        panic!(
+            "Failed to parse environment variable value from key: {}",
+            key
+        );
     }
 }


### PR DESCRIPTION
Improves environment variable error handling.

---

## Example

If an environment variable has an invalid type at the moment of parsing:

```
thread 'main' panicked at 'Failed to parse environment variable value from key: PORT', src/config.rs:31:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

If an environment variable is missing:

```
thread 'main' panicked at 'Missing environment variable: PORT', src/config.rs:25:46
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```