### PR TITLE
feat: `Repository` and `Record` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/context/store.rs
+++ b/src/context/store.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use rand::{distributions::Alphanumeric, Rng};
 use sled::{Config, Db};
 
 pub struct Store {
@@ -17,13 +16,5 @@ impl Store {
         let db = sled_config.open().expect("Failed to create Sled instance");
 
         Self { db }
-    }
-
-    pub fn generate_id(&self) -> String {
-        rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(16)
-            .map(char::from)
-            .collect::<String>()
     }
 }

--- a/src/handlers/redirect.rs
+++ b/src/handlers/redirect.rs
@@ -5,6 +5,7 @@ use axum::Extension;
 
 use crate::context::SharedContext;
 
+#[allow(dead_code)]
 pub async fn redirect(
     _ctx: Extension<SharedContext>,
     Path(_hash): Path<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod context;
 mod handlers;
 mod modules;
+mod shared;
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/src/modules/link/graphql/mutation/link_create.rs
+++ b/src/modules/link/graphql/mutation/link_create.rs
@@ -10,7 +10,7 @@ use crate::{
         auth::service::Token,
         link::{
             graphql::{Link, LinkError, LinkErrorCode},
-            service::CreateLinkDto,
+            repository::CreateLinkDto,
         },
     },
 };
@@ -40,7 +40,7 @@ impl LinkCreate {
         });
 
         let owner = if let Some(claims) = user_claims {
-            Some(context.services.user.get(claims.uid))
+            Some(context.services.user.get(claims.uid).unwrap())
         } else {
             None
         };

--- a/src/modules/link/mod.rs
+++ b/src/modules/link/mod.rs
@@ -1,3 +1,4 @@
 pub mod graphql;
 pub mod model;
+pub mod repository;
 pub mod service;

--- a/src/modules/link/model.rs
+++ b/src/modules/link/model.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+use crate::shared::repository::Record;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Link {
     pub id: String,
     pub hash: String,
@@ -10,4 +12,14 @@ pub struct Link {
     pub created_at: DateTime<Local>,
     pub updated_at: DateTime<Local>,
     pub owner_id: Option<String>,
+}
+
+impl Record for Link {
+    fn get_id(&self) -> String {
+        self.id.to_string()
+    }
+
+    fn set_id(&mut self, id: &str) {
+        self.id = id.to_string()
+    }
 }

--- a/src/modules/link/repository.rs
+++ b/src/modules/link/repository.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::context::Store;
+use crate::shared::repository::Repository;
+
+use super::model::Link;
+
+const LINK_REPOSITORY_TREE: char = 'l';
+
+pub struct LinkRepository {
+    store: Arc<Store>,
+}
+
+impl LinkRepository {
+    pub fn new(store: Arc<Store>) -> Self {
+        Self { store }
+    }
+}
+
+impl Repository<LINK_REPOSITORY_TREE, Link> for LinkRepository {
+    type Error = ();
+
+    fn get_tree(&self) -> sled::Result<sled::Tree> {
+        self.store.db.open_tree(LINK_REPOSITORY_TREE.to_string())
+    }
+}
+
+#[derive(Serialize)]
+pub struct CreateLinkDto {
+    pub original_url: String,
+    pub owner_id: Option<String>,
+    pub custom_hash: Option<String>,
+}
+
+impl From<CreateLinkDto> for Link {
+    fn from(value: CreateLinkDto) -> Self {
+        Self {
+            id: String::from(""),
+            hash: String::from(""),
+            original_url: value.original_url,
+            owner_id: value.owner_id,
+            ..Default::default()
+        }
+    }
+}

--- a/src/modules/link/service.rs
+++ b/src/modules/link/service.rs
@@ -1,62 +1,31 @@
 use std::sync::Arc;
 
-use crate::{context::Store, modules::link::model::Link};
+use crate::{context::Store, modules::link::model::Link, shared::repository::Repository};
+
+use super::repository::{CreateLinkDto, LinkRepository};
 
 pub struct LinkService {
-    store: Arc<Store>,
-}
-
-pub struct CreateLinkDto {
-    pub original_url: String,
-    pub owner_id: Option<String>,
-    pub custom_hash: Option<String>,
-}
-
-impl From<CreateLinkDto> for Link {
-    fn from(value: CreateLinkDto) -> Self {
-        Self {
-            id: String::from(""),
-            hash: String::from(""),
-            original_url: value.original_url,
-            owner_id: value.owner_id,
-            created_at: Default::default(),
-            expires_at: Default::default(),
-            updated_at: Default::default(),
-        }
-    }
+    repository: Arc<LinkRepository>,
 }
 
 impl LinkService {
     pub fn new(store: Arc<Store>) -> Self {
-        Self { store }
+        Self {
+            repository: Arc::new(LinkRepository::new(store)),
+        }
     }
 
-    pub fn get_all(&self) -> Vec<Link> {
-        let link_tree = self.store.db.open_tree("links").unwrap();
-        link_tree
-            .iter()
-            .map(|item| {
-                let (_, v) = item.unwrap();
-                bincode::deserialize(&v).unwrap()
-            })
-            .collect()
+    #[allow(dead_code)]
+    pub fn list(&self) -> Vec<Link> {
+        self.repository.list().unwrap()
     }
 
-    pub fn get(&self, id: String) -> Link {
-        let link_tree = self.store.db.open_tree("links").unwrap();
-        let link = link_tree.get(id).unwrap().unwrap();
-
-        bincode::deserialize(&link).unwrap()
+    #[allow(dead_code)]
+    pub fn get(&self, id: String) -> Option<Link> {
+        self.repository.find_by_id(id).unwrap()
     }
 
-    pub fn create(&self, link: CreateLinkDto) -> Link {
-        let link_tree = self.store.db.open_tree("links").unwrap();
-        let id = self.store.generate_id();
-        let mut link = Link::from(link);
-        link.id = id;
-        let encoded = bincode::serialize(&link).unwrap();
-
-        link_tree.insert(&link.id, encoded).unwrap();
-        link
+    pub fn create(&self, dto: CreateLinkDto) -> Link {
+        self.repository.create(dto).unwrap()
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -4,19 +4,13 @@ pub mod user;
 
 use async_graphql::{EmptySubscription, MergedObject, Schema};
 
-// use self::auth::graphql::{AuthMutationRoot, AuthQueryRoot};
 use self::link::graphql::{LinkMutationRoot, LinkQueryRoot};
 use self::user::graphql::{UserMutationRoot, UserQueryRoot};
 
 #[derive(MergedObject, Default)]
-pub struct MutationRoot(
-    pub LinkMutationRoot,
-    pub UserMutationRoot,
-    // pub AuthMutationRoot,
-);
+pub struct MutationRoot(pub LinkMutationRoot, pub UserMutationRoot);
 
 #[derive(MergedObject, Default)]
 pub struct QueryRoot(pub LinkQueryRoot, pub UserQueryRoot);
-// pub struct QueryRoot(pub AuthQueryRoot, pub UserQueryRoot);
 
 pub type GraphQLSchema = Schema<QueryRoot, MutationRoot, EmptySubscription>;

--- a/src/modules/user/graphql/mutation/user_create.rs
+++ b/src/modules/user/graphql/mutation/user_create.rs
@@ -5,7 +5,7 @@ use crate::{
     context::SharedContext,
     modules::{
         auth::graphql::User,
-        user::{graphql::UserError, service::CreateUserDto},
+        user::{graphql::UserError, repository::CreateUserDto},
     },
 };
 

--- a/src/modules/user/graphql/query/me.rs
+++ b/src/modules/user/graphql/query/me.rs
@@ -22,7 +22,7 @@ impl Me {
         if let Some(jwt) = ctx.data_opt::<Token>() {
             let claims = context.services.auth.verify_token(jwt).unwrap();
             let user = context.services.user.get(claims.uid);
-            let result = User::from(user);
+            let result = User::from(user.unwrap());
 
             return Ok(Me {
                 user: Some(result),

--- a/src/modules/user/mod.rs
+++ b/src/modules/user/mod.rs
@@ -1,3 +1,4 @@
 pub mod graphql;
 pub mod model;
+pub mod repository;
 pub mod service;

--- a/src/modules/user/model.rs
+++ b/src/modules/user/model.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+use crate::shared::repository::Record;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct User {
     pub id: String,
     pub name: String,
@@ -10,4 +12,14 @@ pub struct User {
     pub hash: String,
     pub created_at: DateTime<Local>,
     pub updated_at: DateTime<Local>,
+}
+
+impl Record for User {
+    fn get_id(&self) -> String {
+        self.id.to_string()
+    }
+
+    fn set_id(&mut self, id: &str) {
+        self.id = id.to_string()
+    }
 }

--- a/src/modules/user/repository.rs
+++ b/src/modules/user/repository.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::context::Store;
+use crate::shared::repository::Repository;
+
+use super::model::User;
+
+const USER_REPOSITORY_TREE: char = 'u';
+
+pub struct UserRepository {
+    store: Arc<Store>,
+}
+
+impl UserRepository {
+    pub fn new(store: Arc<Store>) -> Self {
+        Self { store }
+    }
+}
+
+impl Repository<USER_REPOSITORY_TREE, User> for UserRepository {
+    type Error = ();
+
+    fn get_tree(&self) -> sled::Result<sled::Tree> {
+        self.store.db.open_tree(USER_REPOSITORY_TREE.to_string())
+    }
+}
+
+#[derive(Serialize)]
+pub struct CreateUserDto {
+    pub name: String,
+    pub last_name: String,
+    pub email: String,
+    pub hash: String,
+}
+
+impl From<CreateUserDto> for User {
+    fn from(value: CreateUserDto) -> Self {
+        User {
+            name: value.name,
+            last_name: value.last_name,
+            email: value.email,
+            hash: value.hash,
+            ..Default::default()
+        }
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,0 +1,1 @@
+pub mod repository;

--- a/src/shared/repository.rs
+++ b/src/shared/repository.rs
@@ -1,0 +1,78 @@
+use bincode::{deserialize, serialize};
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Length of the random hash created by the `new_id` method
+const ID_LEN: usize = 16;
+
+/// A record represents an entity stored into the tree
+pub trait Record {
+    /// Retrieves the Record's ID
+    fn get_id(&self) -> String;
+    /// Sets the Record's ID
+    fn set_id(&mut self, id: &str);
+}
+
+pub trait Repository<const TREE: char, T: DeserializeOwned + Record + Serialize + Send> {
+    type Error;
+
+    /// Retrieves a tree fromt the Sled instance
+    fn get_tree(&self) -> sled::Result<sled::Tree>;
+
+    /// Generates a new random ID to use for storing new records into a tree
+    fn new_id(&self) -> String {
+        let id = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(ID_LEN)
+            .map(char::from)
+            .collect::<String>();
+
+        format!("{TREE}_{id}")
+    }
+
+    /// Inserts a new Record into the tree by creating an instance of the
+    /// record from a DTO
+    fn create<U>(&self, dto: U) -> Result<T, Self::Error>
+    where
+        U: Into<T> + Send + Serialize,
+    {
+        let tree = self.get_tree().unwrap();
+        let id = self.new_id();
+        let mut record: T = dto.into();
+
+        record.set_id(&id);
+        let encoded = serialize(&record).unwrap();
+
+        tree.insert(id, encoded).unwrap();
+
+        Ok(record)
+    }
+
+    /// Fetches a record from the tree by its ID
+    fn find_by_id(&self, id: String) -> Result<Option<T>, Self::Error> {
+        let tree = self.get_tree().unwrap();
+        let maybe_encoded_record = tree.get(id.as_bytes()).unwrap();
+
+        if let Some(encoded_record) = maybe_encoded_record {
+            let record: T = deserialize(&encoded_record).unwrap();
+
+            return Ok(Some(record));
+        }
+
+        Ok(None)
+    }
+
+    /// Retrieves every record from the tree
+    fn list(&self) -> Result<Vec<T>, Self::Error> {
+        let tree = self.get_tree().unwrap();
+
+        tree.iter()
+            .map(|item| {
+                let (_, encoded_record) = item.unwrap();
+                Ok(bincode::deserialize::<T>(&encoded_record).unwrap())
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
Introduces the `Record` and `Repository` traits in order to reduce
code duplication. Also provides prefixes for IDs based on its trees.