### PR TITLE
fix: set the dates with the current date

### DIFF
--- a/src/modules/link/repository.rs
+++ b/src/modules/link/repository.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::Local;
 use serde::Serialize;
 
 use crate::context::Store;
@@ -39,6 +40,8 @@ impl From<CreateLinkDto> for Link {
         Self {
             original_url: value.original_url,
             owner_id: value.owner_id,
+            created_at: Local::now(),
+            updated_at: Local::now(),
             ..Default::default()
         }
     }

--- a/src/modules/user/repository.rs
+++ b/src/modules/user/repository.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::Local;
 use serde::Serialize;
 
 use crate::context::Store;
@@ -42,6 +43,8 @@ impl From<CreateUserDto> for User {
             surname: value.surname,
             email: value.email,
             password_hash: value.password_hash,
+            created_at: Local::now(),
+            updated_at: Local::now(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
This commit fixes issue #39 

However, I do not totally agree with use Local in place of UTC.
This change set by default the current date in the creation of Links and Users